### PR TITLE
Allow for class prefix to be customized.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ import { FaucetButton, themes: { mono } } from 'wavelet-faucet';
     theme={altTheme} // optional, see src/theme.js for values
     style={{}} // styles the button 
     address="optional address prefill"
+    classPrefix=""  // optional, prefix for all CSS classes inside the faucet. Will use 'wavelet-faucet' by default
     className={{}} // className for the button 
 />
 ```

--- a/src/Faucet.jsx
+++ b/src/Faucet.jsx
@@ -91,7 +91,7 @@ const FaucetLink = styled(ButtonOutlined)`
   }
 `;
 
-const Faucet = ({ style, className, url, header, address: initial }) => {
+const Faucet = ({ style, className, url, header, address: initial, classPrefix }) => {
   const [count, setCount] = useState();
   const [loading, setLoading] = useState();
   const [address, setAddress] = useState(initial || "");
@@ -150,21 +150,20 @@ const Faucet = ({ style, className, url, header, address: initial }) => {
   }, []);
 
   return (
-      <>
     <Wrapper style={style} className={className}>
       { header ? <h1>Quick PERL Faucet</h1> : ''}
-      <CenterContent className="faucet-content">
+      <CenterContent className={`${classPrefix}-content`}>
         {loading ? (
           <LoadingSpinner />
         ) : count === 0 ? (
-          <FormWrapper className="faucet-form" onSubmit={fetchPERLs}>
+          <FormWrapper className={`${classPrefix}-form`} onSubmit={fetchPERLs}>
             <StyledInput
-              className="faucet-input"
+              className={`${classPrefix}-input`}
               value={address}
               placeholder="Enter a wallet address"
               onChange={addressChangeHandle}
             />
-            <Button className="faucet-submit" type="submit" disabled={!address}>
+            <Button className={`${classPrefix}-submit`} type="submit" disabled={!address}>
               Get PERLs
             </Button>
           </FormWrapper>
@@ -172,14 +171,13 @@ const Faucet = ({ style, className, url, header, address: initial }) => {
           count && <h3>You need wait another {count} seconds.</h3>
         )}
       </CenterContent>
-      <FaucetText className="faucet-text">
+      <FaucetText className={`${classPrefix}-text`}>
         Need more <b>PERLs</b>? Join our
         <a href="https://discord.gg/dMYfDPM" target="_blank">
-          <FaucetLink className="faucet-discord">Discord</FaucetLink>
+          <FaucetLink className={`${classPrefix}-discord`}>Discord</FaucetLink>
         </a>
       </FaucetText>
     </Wrapper>
-      </>
   );
 };
 

--- a/src/Faucet.jsx
+++ b/src/Faucet.jsx
@@ -153,17 +153,18 @@ const Faucet = ({ style, className, url, header, address: initial }) => {
       <>
     <Wrapper style={style} className={className}>
       { header ? <h1>Quick PERL Faucet</h1> : ''}
-      <CenterContent>
+      <CenterContent className="faucet-content">
         {loading ? (
           <LoadingSpinner />
         ) : count === 0 ? (
-          <FormWrapper onSubmit={fetchPERLs}>
+          <FormWrapper className="faucet-form" onSubmit={fetchPERLs}>
             <StyledInput
+              className="faucet-input"
               value={address}
               placeholder="Enter a wallet address"
               onChange={addressChangeHandle}
             />
-            <Button type="submit" disabled={!address}>
+            <Button className="faucet-submit" type="submit" disabled={!address}>
               Get PERLs
             </Button>
           </FormWrapper>
@@ -171,10 +172,10 @@ const Faucet = ({ style, className, url, header, address: initial }) => {
           count && <h3>You need wait another {count} seconds.</h3>
         )}
       </CenterContent>
-      <FaucetText>
+      <FaucetText className="faucet-text">
         Need more <b>PERLs</b>? Join our
         <a href="https://discord.gg/dMYfDPM" target="_blank">
-          <FaucetLink>Discord</FaucetLink>
+          <FaucetLink className="faucet-discord">Discord</FaucetLink>
         </a>
       </FaucetText>
     </Wrapper>

--- a/src/FaucetButton.jsx
+++ b/src/FaucetButton.jsx
@@ -11,7 +11,8 @@ const FaucetButton = ({
   modalHeader,
   address,
   url,
-  theme: defaultTheme
+  theme: defaultTheme,
+  children
 }) => {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
@@ -27,7 +28,7 @@ const FaucetButton = ({
           <Faucet address={address} header={!modalHeader} url={url} />
         </Modal>
         <Button style={style} className={className} onClick={handleOpen}>
-          Wavelet Faucet
+          {children || 'Wavelet Faucet'}
         </Button>
       </div>
     </ThemeProvider>

--- a/src/FaucetButton.jsx
+++ b/src/FaucetButton.jsx
@@ -11,6 +11,7 @@ const FaucetButton = ({
   modalHeader,
   address,
   url,
+  classPrefix = 'wavelet-faucet',
   theme: defaultTheme,
   children
 }) => {
@@ -24,8 +25,9 @@ const FaucetButton = ({
           header={modalHeader ? <h2>PERL Faucet</h2> : ""}
           open={open}
           onClose={handleClose}
+          classPrefix={classPrefix}
         >
-          <Faucet address={address} header={!modalHeader} url={url} />
+          <Faucet address={address} header={!modalHeader} url={url} classPrefix={classPrefix}/>
         </Modal>
         <Button style={style} className={className} onClick={handleOpen}>
           {children || 'Wavelet Faucet'}

--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -61,7 +61,7 @@ const ModalCloseButton = styled(({ onClick, className }) => (
   cursor: pointer;
 `;
 
-const Modal = ({ onClose, header, open, children, theme }) => {
+const Modal = ({ onClose, header, open, children, theme, classPrefix }) => {
   const preventEventBubbling = useCallback(e => {
     e.stopPropagation();
   }, []);
@@ -69,23 +69,23 @@ const Modal = ({ onClose, header, open, children, theme }) => {
   return (
     <React.Fragment>
       {open && (
-        <ModalBackdrop className="modal-backdrop" onClick={onClose}>
+        <ModalBackdrop className={`${classPrefix}-modal-backdrop`} onClick={onClose}>
           <ModalWrapper
-            className="modal-wrapper"
+            className={`${classPrefix}-modal-wrapper`}
             onClick={preventEventBubbling}
           >
             <ModalHeader
-              className="modal-header"
+              className={`${classPrefix}-modal-header`}
               justifyContent="space-between"
               hasHeader={header && true}
             >
               {header}
               <ModalCloseButton
-                className="modal-close-button"
+                className={`${classPrefix}-modal-close-button`}
                 onClick={onClose}
               />
             </ModalHeader>
-            <ModalBody className="modal-body">{children}</ModalBody>
+            <ModalBody className={`${classPrefix}-modal-body`}>{children}</ModalBody>
           </ModalWrapper>
         </ModalBackdrop>
       )}


### PR DESCRIPTION
Added customizable Faucet Button label by using the **children** prop and defaulting to 'Wavelet Faucet' if there's no children.

Also added a few CSS classes to the Faucet Modal elements. Using these, allows outside customization and avoids some CSS selector specificity issues.
Ex. Overriding some Faucet input styling may require using **!important** because the unique, styled-component, classes take precedence.