### PR TITLE
Fix message on faucet success alert

### DIFF
--- a/src/Faucet.jsx
+++ b/src/Faucet.jsx
@@ -123,8 +123,9 @@ const Faucet = ({ style, className, url, header, address: initial, classPrefix }
       setLoading(true);
       try {
         const response = await getPERLs(address);
+        const amount = (typeof response.amount !== "undefined") ? ` ${response.amount} ` : " ";
         if (response.result === "ok") {
-          alert("Successfully sent 1000 PERLs.");
+          alert(`Successfully sent${amount}PERLs.`);
         } else {
           throw new Error(response.result);
         }

--- a/src/Faucet.jsx
+++ b/src/Faucet.jsx
@@ -123,9 +123,9 @@ const Faucet = ({ style, className, url, header, address: initial, classPrefix }
       setLoading(true);
       try {
         const response = await getPERLs(address);
-        const amount = (typeof response.amount !== "undefined") ? ` ${response.amount} ` : " ";
+        const amount = (typeof response.amount !== "undefined") ? `${response.amount} ` : "";
         if (response.result === "ok") {
-          alert(`Successfully sent${amount}PERLs.`);
+          alert(`Successfully sent ${amount}PERLs.`);
         } else {
           throw new Error(response.result);
         }


### PR DESCRIPTION
Should replace the hard-coded 'Successfully sent 1000 PERLs' to either show the proper PERL amount (if available on the response.amount) or just show 'Successfully sent PERLs' if not.